### PR TITLE
redesign: clean portfolio, drop AI-slop template

### DIFF
--- a/about.html
+++ b/about.html
@@ -3,47 +3,44 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>DeelerDev</title>
+    <title>About | DeelerDev</title>
     <link rel="icon" type="image/x-icon" href="assets/logo.png">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
     <header>
-        <h1>DeelerDev</h1>
-        <nav>
-            <ul>
-                <li><a href="index.html">Home</a></li>
-                <li><a href="about.html">About</a></li>
-            </ul>
-        </nav>
+        <div class="header-inner">
+            <a href="index.html" class="logo">DeelerDev</a>
+            <nav>
+                <a href="https://github.com/deelerdev" target="_blank" rel="noopener">GitHub</a>
+                <a href="about.html">About</a>
+            </nav>
+        </div>
     </header>
+
     <main>
-        <section class="about-section">
-            <h2>About DeelerDev</h2>
-            <div class="about-content">
-                <p>
-                    DeelerDev is a forward-thinking technology company dedicated to creating innovative solutions 
-                    that shape the future. We combine cutting-edge technology with creative problem-solving to 
-                    deliver exceptional products and services.
-                </p>
-                <p>
-                    Our team of passionate developers, designers, and innovators work tirelessly to bring 
-                    groundbreaking ideas to life. We believe in the power of technology to transform industries 
-                    and improve lives around the world.
-                </p>
-                <p>
-                    <strong>Our Mission:</strong> To push the boundaries of what's possible and create technology 
-                    that empowers people and businesses to achieve their full potential.
-                </p>
-                <p>
-                    <strong>Connect with us:</strong> Check out our projects and contributions on 
-                    <a href="https://github.com/deelerdev" target="_blank">GitHub</a>
-                </p>
-            </div>
+        <section class="intro">
+            <h1>About</h1>
+        </section>
+
+        <section class="section">
+            <p class="tagline" style="margin-bottom: 1.5rem;">
+                DeelerDev is a GitHub org for random projects. JavaScript, TypeScript, C, whatever's interesting at the time.
+            </p>
+            <p class="tagline" style="margin-bottom: 1.5rem;">
+                Forks of useful tools, a p-stream client, some GitHub stats experiments, and a Linux kernel source tree for good measure.
+            </p>
+            <p class="tagline">
+                <a href="https://github.com/deelerdev" target="_blank" rel="noopener" style="color: var(--accent); text-decoration: none;">github.com/deelerdev</a>
+            </p>
         </section>
     </main>
+
     <footer>
-        <p>&copy; 2025 DeelerDev</p>
+        <p>DeelerDev</p>
     </footer>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -7,34 +7,90 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>DeelerDev</title>
     <link rel="icon" type="image/x-icon" href="assets/logo.png">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
     <header>
-        <h1>DeelerDev</h1>
-        <nav>
-            <ul>
-                <li><a href="index.html">Home</a></li>
-                <li><a href="about.html">About</a></li>
-            </ul>
-        </nav>
+        <div class="header-inner">
+            <a href="index.html" class="logo">DeelerDev</a>
+            <nav>
+                <a href="https://github.com/deelerdev" target="_blank" rel="noopener">GitHub</a>
+                <a href="about.html">About</a>
+            </nav>
+        </div>
     </header>
+
     <main>
-        <section class="hero">
-            <h2>Building the Future of Technology</h2>
-            <p>DeelerDev is a cutting-edge tech company creating innovative solutions and pushing the boundaries of what's possible.</p>
-            <a href="about.html" class="cta-button">Learn More</a>
+        <section class="intro">
+            <h1>A place for <span class="accent">random projects</span>.</h1>
+            <p class="tagline">Some useful, some not. All on GitHub.</p>
         </section>
 
-        <section class="projects">
-            <h2>Our Projects</h2>
-            <div class="coming-soon">
-                <p>🚀 Exciting projects coming soon!</p>
+        <section class="section">
+            <h2 class="section-heading">Repos</h2>
+            <div class="repo-list" id="repoList">
+                <p class="loading">Loading repos...</p>
             </div>
         </section>
     </main>
+
     <footer>
-        <p>&copy; 2025 DeelerDev</p>
+        <p>DeelerDev</p>
     </footer>
+
+    <script>
+        fetch('https://api.github.com/orgs/DeelerDev/repos?per_page=100&sort=updated')
+            .then(r => r.json())
+            .then(repos => {
+                const list = document.getElementById('repoList');
+                list.innerHTML = '';
+
+                repos
+                    .filter(r => !r.archived)
+                    .sort((a, b) => b.stargazers_count - a.stargazers_count)
+                    .forEach(repo => {
+                        const item = document.createElement('a');
+                        item.className = 'repo-item';
+                        item.href = repo.html_url;
+                        item.target = '_blank';
+                        item.rel = 'noopener';
+
+                        const lang = repo.language || 'misc';
+                        const stars = repo.stargazers_count > 0
+                            ? `<span class="repo-stars">&#9733; ${repo.stargazers_count}</span>`
+                            : '';
+
+                        item.innerHTML = `
+                            <div class="repo-top">
+                                <span class="repo-name">${repo.name}</span>
+                                ${stars}
+                            </div>
+                            <p class="repo-desc">${repo.description || 'No description.'}</p>
+                            <div class="repo-meta">
+                                <span class="repo-lang">${lang}</span>
+                                <span class="repo-updated">updated ${formatDate(repo.pushed_at)}</span>
+                            </div>
+                        `;
+                        list.appendChild(item);
+                    });
+            })
+            .catch(() => {
+                document.getElementById('repoList').innerHTML =
+                    '<p class="loading">Could not load repos. Visit <a href="https://github.com/deelerdev" target="_blank">GitHub</a>.</p>';
+            });
+
+        function formatDate(iso) {
+            const d = new Date(iso);
+            const now = new Date();
+            const months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+            if (d.getFullYear() === now.getFullYear()) {
+                return months[d.getMonth()] + ' ' + d.getDate();
+            }
+            return months[d.getMonth()] + ' ' + d.getFullYear();
+        }
+    </script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -1,4 +1,4 @@
-/* Modern Tech Company Styling for DeelerDev */
+/* DeelerDev -- plain, honest, no slop */
 
 * {
     margin: 0;
@@ -7,339 +7,229 @@
 }
 
 :root {
-    --primary-color: #6366f1;
-    --secondary-color: #8b5cf6;
-    --accent-color: #ec4899;
-    --dark-bg: #0f172a;
-    --card-bg: #1e293b;
-    --text-light: #f1f5f9;
-    --text-gray: #94a3b8;
-    --gradient-1: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    --gradient-2: linear-gradient(135deg, #f093fb 0%, #f5576c 100%);
-    --gradient-3: linear-gradient(135deg, #4facfe 0%, #00f2fe 100%);
+    --bg: #1a1a1a;
+    --surface: #242424;
+    --border: #333;
+    --text: #ddd;
+    --text-muted: #888;
+    --accent: #e8a838;
+}
+
+html {
+    scroll-behavior: smooth;
 }
 
 body {
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', sans-serif;
-    background: var(--dark-bg);
-    color: var(--text-light);
-    line-height: 1.6;
+    font-family: 'Inter', -apple-system, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.7;
     min-height: 100vh;
     display: flex;
     flex-direction: column;
 }
 
-/* Header Styles */
+/* Header */
 header {
-    background: rgba(15, 23, 42, 0.95);
-    backdrop-filter: blur(10px);
-    padding: 1rem 2rem;
+    border-bottom: 1px solid var(--border);
     position: sticky;
     top: 0;
-    z-index: 1000;
-    border-bottom: 1px solid rgba(99, 102, 241, 0.2);
+    background: var(--bg);
+    z-index: 100;
 }
 
-header h1 {
-    font-size: 2rem;
-    background: var(--gradient-1);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    display: inline-block;
-    margin-bottom: 0.5rem;
-    font-weight: 700;
-    letter-spacing: -1px;
-}
-
-nav ul {
-    list-style: none;
+.header-inner {
+    max-width: 680px;
+    margin: 0 auto;
+    padding: 1rem 1.5rem;
     display: flex;
-    gap: 2rem;
-    margin-top: 0.5rem;
+    justify-content: space-between;
+    align-items: center;
 }
 
-nav ul li a {
-    color: var(--text-gray);
+.logo {
+    font-weight: 700;
+    font-size: 1rem;
+    color: var(--text);
     text-decoration: none;
+    letter-spacing: -0.01em;
+}
+
+nav {
+    display: flex;
+    gap: 1.25rem;
+}
+
+nav a {
+    color: var(--text-muted);
+    text-decoration: none;
+    font-size: 0.88rem;
     font-weight: 500;
-    transition: all 0.3s ease;
-    padding: 0.5rem 1rem;
-    border-radius: 0.5rem;
-    position: relative;
+    transition: color 0.15s;
 }
 
-nav ul li a:hover {
-    color: var(--text-light);
-    background: rgba(99, 102, 241, 0.1);
+nav a:hover {
+    color: var(--text);
 }
 
-nav ul li a::after {
-    content: '';
-    position: absolute;
-    bottom: 0;
-    left: 50%;
-    width: 0;
-    height: 2px;
-    background: var(--primary-color);
-    transition: all 0.3s ease;
-    transform: translateX(-50%);
-}
-
-nav ul li a:hover::after {
-    width: 80%;
-}
-
-/* Main Content */
+/* Main */
 main {
     flex: 1;
-    padding: 2rem;
-    max-width: 1200px;
+    max-width: 680px;
     width: 100%;
     margin: 0 auto;
+    padding: 0 1.5rem;
 }
 
-/* Hero Section */
-.hero {
-    text-align: center;
-    padding: 4rem 2rem;
-    margin-bottom: 4rem;
+/* Intro */
+.intro {
+    padding: 4rem 0 3rem;
 }
 
-.hero h2 {
-    font-size: 3.5rem;
-    margin-bottom: 1.5rem;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 50%, #f093fb 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    font-weight: 800;
-    line-height: 1.2;
+.intro h1 {
+    font-size: 2.2rem;
+    font-weight: 700;
+    letter-spacing: -0.03em;
+    line-height: 1.15;
+    margin-bottom: 0.5rem;
 }
 
-.hero p {
-    font-size: 1.25rem;
-    color: var(--text-gray);
-    max-width: 600px;
-    margin: 0 auto 2rem;
+.accent {
+    color: var(--accent);
 }
 
-.cta-button {
-    display: inline-block;
-    padding: 1rem 2rem;
-    background: var(--gradient-1);
-    color: white;
-    text-decoration: none;
-    border-radius: 0.75rem;
-    font-weight: 600;
-    transition: all 0.3s ease;
-    box-shadow: 0 4px 15px rgba(99, 102, 241, 0.4);
-}
-
-.cta-button:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 6px 25px rgba(99, 102, 241, 0.6);
-}
-
-/* Projects Section */
-.projects {
-    margin-top: 4rem;
-}
-
-.projects h2 {
-    font-size: 2.5rem;
-    margin-bottom: 2rem;
-    text-align: center;
-    background: var(--gradient-3);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-}
-
-.coming-soon {
-    text-align: center;
-    padding: 4rem 2rem;
-    background: var(--card-bg);
-    border-radius: 1rem;
-    border: 1px solid rgba(99, 102, 241, 0.2);
-    margin-top: 2rem;
-}
-
-.coming-soon p {
-    font-size: 1.5rem;
-    color: var(--text-gray);
-    animation: fadeInUp 0.6s ease-out;
-}
-
-.project-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-    gap: 2rem;
-    margin-top: 2rem;
-}
-
-.project-card {
-    background: var(--card-bg);
-    border-radius: 1rem;
-    padding: 2rem;
-    transition: all 0.3s ease;
-    border: 1px solid rgba(99, 102, 241, 0.2);
-    position: relative;
-    overflow: hidden;
-}
-
-.project-card::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 4px;
-    background: var(--gradient-1);
-    transform: scaleX(0);
-    transition: transform 0.3s ease;
-}
-
-.project-card:hover::before {
-    transform: scaleX(1);
-}
-
-.project-card:hover {
-    transform: translateY(-5px);
-    box-shadow: 0 10px 40px rgba(99, 102, 241, 0.3);
-    border-color: rgba(99, 102, 241, 0.5);
-}
-
-.project-card h3 {
-    font-size: 1.5rem;
-    margin-bottom: 1rem;
-    color: var(--text-light);
-}
-
-.project-card p {
-    color: var(--text-gray);
-    margin-bottom: 1rem;
-}
-
-.project-status {
-    display: inline-block;
-    padding: 0.25rem 0.75rem;
-    background: rgba(99, 102, 241, 0.2);
-    color: var(--primary-color);
-    border-radius: 0.5rem;
-    font-size: 0.875rem;
-    font-weight: 600;
-}
-
-.project-status.in-development {
-    background: rgba(236, 72, 153, 0.2);
-    color: var(--accent-color);
-}
-
-/* About Section */
-.about-section {
-    margin-top: 2rem;
-}
-
-.about-section h2 {
-    font-size: 2.5rem;
-    margin-bottom: 2rem;
-    background: var(--gradient-2);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-}
-
-.about-content {
-    background: var(--card-bg);
-    border-radius: 1rem;
-    padding: 2rem;
-    border: 1px solid rgba(99, 102, 241, 0.2);
-    line-height: 1.8;
-}
-
-.about-content p {
-    margin-bottom: 1.5rem;
-    color: var(--text-gray);
+.tagline {
     font-size: 1.1rem;
+    color: var(--text-muted);
 }
 
-.about-content a {
-    color: var(--primary-color);
+/* Sections */
+.section {
+    padding: 1.5rem 0 3rem;
+}
+
+.section-heading {
+    font-size: 1.3rem;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    margin-bottom: 1.25rem;
+}
+
+/* Repo list */
+.repo-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.loading {
+    color: var(--text-muted);
+    font-size: 0.9rem;
+}
+
+.loading a {
+    color: var(--accent);
+}
+
+.repo-item {
+    display: block;
+    padding: 1rem 1.25rem;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 6px;
     text-decoration: none;
-    font-weight: 600;
-    transition: all 0.3s ease;
+    color: var(--text);
+    transition: border-color 0.15s, transform 0.1s;
 }
 
-.about-content a:hover {
-    color: var(--secondary-color);
-    text-decoration: underline;
+.repo-item:hover {
+    border-color: var(--accent);
+    text-decoration: none;
+}
+
+.repo-top {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 0.35rem;
+}
+
+.repo-name {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.95rem;
+    font-weight: 500;
+    color: var(--accent);
+}
+
+.repo-stars {
+    font-size: 0.85rem;
+    color: var(--text-muted);
+}
+
+.repo-stars {
+    white-space: nowrap;
+}
+
+.repo-desc {
+    font-size: 0.88rem;
+    color: var(--text-muted);
+    margin-bottom: 0.5rem;
+}
+
+.repo-meta {
+    display: flex;
+    gap: 1rem;
+    font-size: 0.78rem;
+    color: var(--text-muted);
+    font-family: 'JetBrains Mono', monospace;
+}
+
+.repo-lang::before {
+    content: '';
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--accent);
+    margin-right: 0.35rem;
+    vertical-align: middle;
 }
 
 /* Footer */
 footer {
-    background: rgba(15, 23, 42, 0.95);
-    padding: 2rem;
+    border-top: 1px solid var(--border);
+    padding: 1.5rem;
     text-align: center;
-    border-top: 1px solid rgba(99, 102, 241, 0.2);
-    margin-top: 4rem;
 }
 
 footer p {
-    color: var(--text-gray);
+    color: var(--text-muted);
+    font-size: 0.82rem;
 }
 
-/* Responsive Design */
-@media (max-width: 768px) {
-    header h1 {
-        font-size: 1.5rem;
+/* Responsive */
+@media (max-width: 640px) {
+    .intro {
+        padding: 3rem 0 2rem;
     }
 
-    nav ul {
-        gap: 1rem;
+    .intro h1 {
+        font-size: 1.75rem;
     }
 
-    .hero h2 {
-        font-size: 2rem;
-    }
-
-    .hero p {
+    .tagline {
         font-size: 1rem;
     }
 
-    .project-grid {
-        grid-template-columns: 1fr;
-    }
-
-    main {
-        padding: 1rem;
+    .header-inner {
+        padding: 0.75rem 1rem;
     }
 }
 
-/* Animations */
-@keyframes fadeInUp {
-    from {
-        opacity: 0;
-        transform: translateY(30px);
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+    * {
+        transition: none !important;
+        animation: none !important;
     }
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
-}
-
-.hero, .project-card, .about-content {
-    animation: fadeInUp 0.6s ease-out;
-}
-
-.project-card:nth-child(2) {
-    animation-delay: 0.1s;
-}
-
-.project-card:nth-child(3) {
-    animation-delay: 0.2s;
-}
-
-.project-card:nth-child(4) {
-    animation-delay: 0.3s;
 }


### PR DESCRIPTION
## What

Redesign of the DeelerDev GitHub Pages site. The current site looks like an AI-generated SaaS template. This PR replaces it with a clean, honest developer org portfolio.

## Problems with the current site

- Indigo/violet gradient text on every heading (the #1 AI-design tell)
- Glassmorphism header with `backdrop-filter: blur(10px)` and no depth system
- Fake "Building the Future of Technology" copy (DeelerDev is a GitHub org for random projects, not a tech company)
- Dead "coming soon" emoji placeholder instead of actual content
- Centered hero with gradient CTA button
- Generic system fonts with no deliberate type choice
- Feature-tile grid CSS for project cards that don't exist

## What changed

**index.html**
- Left-aligned intro: "A place for random projects. Some useful, some not. All on GitHub."
- Repo list fetched live from the GitHub API (sorted by stars, shows name, description, language, last updated)
- No fake company framing, no emoji placeholders

**about.html**
- Honest copy: "a GitHub org for random projects"
- Links to the actual GitHub org page

**styles.css**
- Dark `#1a1a1a` background with amber `#e8a838` accent (no indigo/violet)
- Inter for body text, JetBrains Mono for repo names and metadata
- No gradients, no blur, no animated entrances
- 680px max-width column, left-aligned
- Responsive (640px breakpoint)
- Respects `prefers-reduced-motion`

## Slop score

Old site: 8/10 (gradient text, generic hue, unearned blur, center stack, default type, wrong surface, fake copy)
New site: 0/10 (none of the 10 AI-design tells present)

## Test plan

- [ ] Page loads, repos populate from API
- [ ] Responsive on mobile
- [ ] About page renders correctly
- [ ] No console errors
